### PR TITLE
[Scrum 22/Feat] enterRoom 구현

### DIFF
--- a/src/main/java/mana/doodleking/domain/room/RoomController.java
+++ b/src/main/java/mana/doodleking/domain/room/RoomController.java
@@ -1,5 +1,6 @@
 package mana.doodleking.domain.room;
 
+import jakarta.persistence.OptimisticLockException;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import mana.doodleking.domain.room.dto.EnterRoomReq;
@@ -51,6 +52,10 @@ public class RoomController {
 
             List<RoomSimple> roomList = roomService.getRoomList();
             messageSender.send("/topic/lobby", roomList);
+        }
+        catch (OptimisticLockException e) {
+            log.warn(e.getMessage());
+            messageSender.sendError("/queue/user/" + userId, "동시성 문제 발생: 다시 시도해주세요.");
         }
         catch (Exception e) {
             log.warn(e.getMessage());

--- a/src/main/java/mana/doodleking/domain/room/RoomService.java
+++ b/src/main/java/mana/doodleking/domain/room/RoomService.java
@@ -26,6 +26,7 @@ public class RoomService {
     private final UserRoomRepository userRoomRepository;
     private final UserRepository userRepository;
 
+    @Transactional
     public RoomDetail createRoom(Long userId, PostRoomReq postRoomReq) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("존재하지 않는 사용자 id: " + userId));

--- a/src/main/java/mana/doodleking/domain/room/RoomService.java
+++ b/src/main/java/mana/doodleking/domain/room/RoomService.java
@@ -1,13 +1,16 @@
 package mana.doodleking.domain.room;
 
 import lombok.AllArgsConstructor;
+import mana.doodleking.domain.room.domain.Room;
+import mana.doodleking.domain.room.domain.UserRoom;
+import mana.doodleking.domain.room.dto.EnterRoomReq;
 import mana.doodleking.domain.room.dto.PostRoomReq;
 import mana.doodleking.domain.room.dto.RoomDetail;
 import mana.doodleking.domain.room.dto.RoomSimple;
 import mana.doodleking.domain.room.repository.RoomRepository;
 import mana.doodleking.domain.room.repository.UserRoomRepository;
-import mana.doodleking.domain.user.User;
-import mana.doodleking.domain.user.UserRole;
+import mana.doodleking.domain.user.domain.User;
+import mana.doodleking.domain.user.enums.UserRole;
 import mana.doodleking.domain.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 
@@ -36,5 +39,22 @@ public class RoomService {
         return roomList.stream()
                 .map(RoomSimple::from)
                 .toList();
+    }
+
+    public RoomDetail enterRoom(Long userId, EnterRoomReq enterRoomReq) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 사용자 id: " + userId));
+        Room enterRoom = roomRepository.findById(enterRoomReq.getRoomId())
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 방 id: " + enterRoomReq.getRoomId()));
+
+        // 방 현재 인원 변경
+        enterRoom.setCurPlayer(enterRoom.getCurPlayer() + 1L);
+        roomRepository.save(enterRoom);
+
+        // 유저 방 소속 관계 생성
+        UserRoom userRoom = UserRoom.of(UserRole.MEMBER, user, enterRoom);
+        userRoomRepository.save(userRoom);
+
+        return RoomDetail.from(enterRoom);
     }
 }

--- a/src/main/java/mana/doodleking/domain/room/RoomService.java
+++ b/src/main/java/mana/doodleking/domain/room/RoomService.java
@@ -13,6 +13,7 @@ import mana.doodleking.domain.user.domain.User;
 import mana.doodleking.domain.user.enums.UserRole;
 import mana.doodleking.domain.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -41,6 +42,7 @@ public class RoomService {
                 .toList();
     }
 
+    @Transactional
     public RoomDetail enterRoom(Long userId, EnterRoomReq enterRoomReq) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("존재하지 않는 사용자 id: " + userId));
@@ -49,7 +51,6 @@ public class RoomService {
 
         // 방 현재 인원 변경
         enterRoom.setCurPlayer(enterRoom.getCurPlayer() + 1L);
-        roomRepository.save(enterRoom);
 
         // 유저 방 소속 관계 생성
         UserRoom userRoom = UserRoom.of(UserRole.MEMBER, user, enterRoom);

--- a/src/main/java/mana/doodleking/domain/room/domain/Room.java
+++ b/src/main/java/mana/doodleking/domain/room/domain/Room.java
@@ -1,9 +1,10 @@
-package mana.doodleking.domain.room;
+package mana.doodleking.domain.room.domain;
 
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import mana.doodleking.domain.room.dto.PostRoomReq;
 import mana.doodleking.domain.room.enums.RoomState;
 import mana.doodleking.domain.room.enums.Subject;
@@ -12,6 +13,7 @@ import java.util.List;
 
 @Entity
 @Getter
+@Setter
 @Table(name = "room")
 @NoArgsConstructor
 public class Room {

--- a/src/main/java/mana/doodleking/domain/room/domain/Room.java
+++ b/src/main/java/mana/doodleking/domain/room/domain/Room.java
@@ -29,6 +29,8 @@ public class Room {
     private Long time;
     private Long round;
     private Boolean hint;
+    @Version
+    private Long version;
 
     @OneToMany(mappedBy = "room", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UserRoom> userRoomList;

--- a/src/main/java/mana/doodleking/domain/room/domain/UserRoom.java
+++ b/src/main/java/mana/doodleking/domain/room/domain/UserRoom.java
@@ -1,12 +1,12 @@
-package mana.doodleking.domain.room;
+package mana.doodleking.domain.room.domain;
 
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import mana.doodleking.domain.user.User;
-import mana.doodleking.domain.user.UserRole;
-import mana.doodleking.domain.user.UserState;
+import mana.doodleking.domain.user.domain.User;
+import mana.doodleking.domain.user.enums.UserRole;
+import mana.doodleking.domain.user.enums.UserState;
 
 @Entity
 @NoArgsConstructor

--- a/src/main/java/mana/doodleking/domain/room/dto/EnterRoomReq.java
+++ b/src/main/java/mana/doodleking/domain/room/dto/EnterRoomReq.java
@@ -1,0 +1,8 @@
+package mana.doodleking.domain.room.dto;
+
+import lombok.Getter;
+
+@Getter
+public class EnterRoomReq {
+    private Long roomId;
+}

--- a/src/main/java/mana/doodleking/domain/room/dto/RoomDetail.java
+++ b/src/main/java/mana/doodleking/domain/room/dto/RoomDetail.java
@@ -1,7 +1,7 @@
 package mana.doodleking.domain.room.dto;
 
 import lombok.*;
-import mana.doodleking.domain.room.Room;
+import mana.doodleking.domain.room.domain.Room;
 import mana.doodleking.domain.room.enums.RoomState;
 import mana.doodleking.domain.room.enums.Subject;
 

--- a/src/main/java/mana/doodleking/domain/room/dto/RoomSimple.java
+++ b/src/main/java/mana/doodleking/domain/room/dto/RoomSimple.java
@@ -3,7 +3,7 @@ package mana.doodleking.domain.room.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import mana.doodleking.domain.room.Room;
+import mana.doodleking.domain.room.domain.Room;
 import mana.doodleking.domain.room.enums.RoomState;
 import mana.doodleking.domain.room.enums.Subject;
 

--- a/src/main/java/mana/doodleking/domain/room/repository/RoomRepository.java
+++ b/src/main/java/mana/doodleking/domain/room/repository/RoomRepository.java
@@ -1,6 +1,6 @@
 package mana.doodleking.domain.room.repository;
 
-import mana.doodleking.domain.room.Room;
+import mana.doodleking.domain.room.domain.Room;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/mana/doodleking/domain/room/repository/UserRoomRepository.java
+++ b/src/main/java/mana/doodleking/domain/room/repository/UserRoomRepository.java
@@ -1,6 +1,6 @@
 package mana.doodleking.domain.room.repository;
 
-import mana.doodleking.domain.room.UserRoom;
+import mana.doodleking.domain.room.domain.UserRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/mana/doodleking/domain/room/repository/UserRoomRepository.java
+++ b/src/main/java/mana/doodleking/domain/room/repository/UserRoomRepository.java
@@ -1,9 +1,11 @@
 package mana.doodleking.domain.room.repository;
 
 import mana.doodleking.domain.room.domain.UserRoom;
+import mana.doodleking.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRoomRepository extends JpaRepository<UserRoom, Long> {
+    boolean existsUserRoomByUser(User user);
 }

--- a/src/main/java/mana/doodleking/domain/user/domain/Character.java
+++ b/src/main/java/mana/doodleking/domain/user/domain/Character.java
@@ -1,4 +1,4 @@
-package mana.doodleking.domain.user;
+package mana.doodleking.domain.user.domain;
 
 import jakarta.persistence.*;
 import lombok.Builder;

--- a/src/main/java/mana/doodleking/domain/user/domain/User.java
+++ b/src/main/java/mana/doodleking/domain/user/domain/User.java
@@ -1,11 +1,11 @@
-package mana.doodleking.domain.user;
+package mana.doodleking.domain.user.domain;
 
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import mana.doodleking.domain.room.UserRoom;
+import mana.doodleking.domain.room.domain.UserRoom;
 import java.time.LocalDateTime;
 import java.util.List;
 

--- a/src/main/java/mana/doodleking/domain/user/dto/CreateUserRes.java
+++ b/src/main/java/mana/doodleking/domain/user/dto/CreateUserRes.java
@@ -2,7 +2,7 @@ package mana.doodleking.domain.user.dto;
 
 import lombok.Builder;
 import lombok.Getter;
-import mana.doodleking.domain.user.User;
+import mana.doodleking.domain.user.domain.User;
 
 @Getter
 public class CreateUserRes {

--- a/src/main/java/mana/doodleking/domain/user/enums/UserRole.java
+++ b/src/main/java/mana/doodleking/domain/user/enums/UserRole.java
@@ -1,4 +1,4 @@
-package mana.doodleking.domain.user;
+package mana.doodleking.domain.user.enums;
 
 public enum UserRole {
     LEADER, MEMBER

--- a/src/main/java/mana/doodleking/domain/user/enums/UserState.java
+++ b/src/main/java/mana/doodleking/domain/user/enums/UserState.java
@@ -1,4 +1,4 @@
-package mana.doodleking.domain.user;
+package mana.doodleking.domain.user.enums;
 
 public enum UserState {
     READY, NOT_READY

--- a/src/main/java/mana/doodleking/domain/user/repository/CharacterRepository.java
+++ b/src/main/java/mana/doodleking/domain/user/repository/CharacterRepository.java
@@ -2,7 +2,7 @@ package mana.doodleking.domain.user.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-import mana.doodleking.domain.user.Character;
+import mana.doodleking.domain.user.domain.Character;
 
 @Repository
 public interface CharacterRepository extends JpaRepository<Character, Long> {

--- a/src/main/java/mana/doodleking/domain/user/repository/UserRepository.java
+++ b/src/main/java/mana/doodleking/domain/user/repository/UserRepository.java
@@ -1,6 +1,6 @@
 package mana.doodleking.domain.user.repository;
 
-import mana.doodleking.domain.user.User;
+import mana.doodleking.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/mana/doodleking/domain/user/service/UserService.java
+++ b/src/main/java/mana/doodleking/domain/user/service/UserService.java
@@ -1,8 +1,8 @@
 package mana.doodleking.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
-import mana.doodleking.domain.user.Character;
-import mana.doodleking.domain.user.User;
+import mana.doodleking.domain.user.domain.Character;
+import mana.doodleking.domain.user.domain.User;
 import mana.doodleking.domain.user.dto.CreateUserReq;
 import mana.doodleking.domain.user.repository.CharacterRepository;
 import mana.doodleking.domain.user.repository.UserRepository;

--- a/src/main/java/mana/doodleking/domain/user/service/UserService.java
+++ b/src/main/java/mana/doodleking/domain/user/service/UserService.java
@@ -24,6 +24,11 @@ public class UserService {
             throw new Exception("존재하지 않는 캐릭터 ID입니다. : " + characterId);
     }
 
+    public User getUserOrThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 사용자 id: " + userId));
+    }
+
     public User createUser(CreateUserReq createUserReq) throws Exception {
         Character character = characterRepository.findCharacterById(createUserReq.getCharacterId());
 

--- a/src/test/java/mana/doodleking/domain/user/service/UserServiceTest.java
+++ b/src/test/java/mana/doodleking/domain/user/service/UserServiceTest.java
@@ -1,7 +1,7 @@
 package mana.doodleking.domain.user.service;
 
-import mana.doodleking.domain.user.Character;
-import mana.doodleking.domain.user.User;
+import mana.doodleking.domain.user.domain.Character;
+import mana.doodleking.domain.user.domain.User;
 import mana.doodleking.domain.user.dto.CreateUserReq;
 import mana.doodleking.domain.user.repository.CharacterRepository;
 import mana.doodleking.domain.user.repository.UserRepository;


### PR DESCRIPTION
## enterRoom 구현
### 📝 요약
유저가 게임 방에 접속하는 enterRoom을 구현했습니다.

유저 및 방에 관한 유효성 검증 후 해당 유저가 방에 속해있는지 여부를 검증해 예외 처리합니다.
이후, 해당 방의 인원 수를 증가시키고 UserRoom을 생성합니다.

위 과정에서 Room 엔티티에 @Version을 추가해 동시성 락을 구현했습니다.
이를 통해 동시에 여러 유저가 Room에 접속시 인원 수 증가 관련 에러를 방지합니다.

아래 링크에 EnterRoom 웹 소켓 테스트 코드 추가해두었습니다:)
[웹 소켓 클라이언트 코드](https://www.notion.so/16c62570e7c4809abaa6eab50eacdb93?p=17962570e7c480ad9792fe34567da78b&pm=c)

<img width="891" alt="Screenshot 2025-01-22 at 6 30 50 PM" src="https://github.com/user-attachments/assets/bad7867a-074b-406a-9dd5-ee162a1a1613" />

### 🛠️ 변경 사항
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [x] 로직에 영향을 미치지 않는 수정(주석 수정, 오타 수정 등)
- [ ] 문서 수정
- [ ] 테스트 코드
- [x] 파일 구조 변경
