### PR TITLE
[Scrum 30/Chore]swagger 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.4.1'
-	id 'io.spring.dependency-management' version '1.1.7'
+	id 'org.springframework.boot' version '3.2.1'
+	id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'mana'
@@ -34,6 +34,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/mana/doodleking/domain/room/RoomController.java
+++ b/src/main/java/mana/doodleking/domain/room/RoomController.java
@@ -5,14 +5,10 @@ import lombok.extern.slf4j.Slf4j;
 import mana.doodleking.domain.room.dto.RoomDetail;
 import mana.doodleking.domain.room.dto.PostRoomReq;
 import mana.doodleking.domain.room.dto.RoomSimple;
-import mana.doodleking.domain.user.dto.CreateUserRes;
 import mana.doodleking.global.MessageSender;
-import mana.doodleking.global.response.APIResponse;
-import mana.doodleking.websocket.RequestChatContentsDto;
+import mana.doodleking.global.swagger.RoomControllerDocs;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.SendTo;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,19 +16,17 @@ import java.util.List;
 
 @Controller
 @AllArgsConstructor
-@RequestMapping("/api/room")
-@RestController
 @Slf4j
-public class RoomController {
+public class RoomController implements RoomControllerDocs {
     private final RoomService roomService;
     private final MessageSender messageSender;
-    @GetMapping
+    @GetMapping("/api/v1/room")
     public List<RoomSimple> getRoomList() {
         return roomService.getRoomList();
     }
 
     @MessageMapping("/createRoom")
-    public void sendMessage(@Header("userId") Long userId, PostRoomReq postRoomReq) {
+    public void createRoom(@Header("userId") Long userId, PostRoomReq postRoomReq) {
         try {
             RoomDetail createdRoom = roomService.createRoom(userId, postRoomReq);
             messageSender.send("/queue/user/" + userId, createdRoom);

--- a/src/main/java/mana/doodleking/domain/user/controller/UserController.java
+++ b/src/main/java/mana/doodleking/domain/user/controller/UserController.java
@@ -1,11 +1,14 @@
 package mana.doodleking.domain.user.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import mana.doodleking.domain.user.dto.CreateUserReq;
 import mana.doodleking.domain.user.dto.CreateUserRes;
 import mana.doodleking.domain.user.service.UserService;
 import mana.doodleking.global.response.APIResponse;
+import mana.doodleking.global.swagger.UserControllerDocs;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,11 +18,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/user")
 @RequiredArgsConstructor
-public class UserController {
+public class UserController implements UserControllerDocs {
     private final UserService userService;
 
-    @PostMapping("")
-    private ResponseEntity<APIResponse<CreateUserRes>> userCreate(@RequestBody @Valid CreateUserReq createUserReq) throws Exception {
+    @Operation(summary = "사용자 생성")
+    @PostMapping
+    public ResponseEntity<APIResponse<CreateUserRes>> userCreate(@RequestBody @Valid CreateUserReq createUserReq) throws Exception {
         // 유저명 중복 검증
         userService.validUserName(createUserReq.getUserName());
         // 캐릭터 ID 존재 검증

--- a/src/main/java/mana/doodleking/global/config/SwaggerConfig.java
+++ b/src/main/java/mana/doodleking/global/config/SwaggerConfig.java
@@ -21,8 +21,12 @@ public class SwaggerConfig {
 
     private Info apiInfo() {
         return new Info()
-                .title("DoodleKing")
-                .description("실시간 그림 퀴즈 게임")
-                .version("1.0.0");
+            .title("DoodleKing")
+            .description("""
+                socket 관련 명세인 경우 해당 메시지(socket) 형식으로 문서화를 하였습니다.\n
+                HTTP 명세의 경우는 테스트가 가능하지만, socket 관련 명세는 테스트가 불가능합니다.
+                """
+            )
+            .version("1.0.0");
     }
 }

--- a/src/main/java/mana/doodleking/global/config/SwaggerConfig.java
+++ b/src/main/java/mana/doodleking/global/config/SwaggerConfig.java
@@ -1,0 +1,28 @@
+package mana.doodleking.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("DoodleKing")
+                .description("실시간 그림 퀴즈 게임")
+                .version("1.0.0");
+    }
+}

--- a/src/main/java/mana/doodleking/global/swagger/RoomControllerDocs.java
+++ b/src/main/java/mana/doodleking/global/swagger/RoomControllerDocs.java
@@ -1,0 +1,29 @@
+package mana.doodleking.global.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import mana.doodleking.domain.room.dto.PostRoomReq;
+import mana.doodleking.domain.room.dto.RoomSimple;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.List;
+
+@Tag(name = "게임방 API", description = "게임방 생성, 조회 및 관련 기능 제공")
+public interface RoomControllerDocs {
+    @Operation(
+        summary = "게임방 목록 조회(테스트용)",
+        description = "현재 생성된 게임방 목록을 전체 조회"
+    )
+    List<RoomSimple> getRoomList();
+
+    @GetMapping("/createRoom(socket)")
+    @Operation(
+        summary = "새로운 게임방 생성",
+        description = """
+        사용자가 새로운 게임방 생성\n
+        생성된 방 정보는 요청한 사용자(/queue/user/{userId})에게 전송되며,
+        전체 로비에 있는 사용자들(/topic/lobby)에게도 전체 게임방 목록이 전송됩니다.
+        """
+    )
+    void createRoom(Long userId, PostRoomReq postRoomReq);
+}

--- a/src/main/java/mana/doodleking/global/swagger/UserControllerDocs.java
+++ b/src/main/java/mana/doodleking/global/swagger/UserControllerDocs.java
@@ -1,0 +1,16 @@
+package mana.doodleking.global.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import mana.doodleking.domain.user.dto.CreateUserReq;
+import mana.doodleking.domain.user.dto.CreateUserRes;
+import mana.doodleking.global.response.APIResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@Tag(name = "사용자 API")
+public interface UserControllerDocs {
+
+    @Operation(summary = "사용자 생성", description = "새로운 사용자를 생성합니다.")
+    ResponseEntity<APIResponse<CreateUserRes>> userCreate(CreateUserReq createUserReq) throws Exception;
+}


### PR DESCRIPTION
## swagger 추가
### 📝 요약
Docs라는 이름의 컨트롤러 인터페이스를 분리하였습니다.
웹 소켓에 사용되는 MessageMapping 어노테이션을 인식해주지는 않아서 메시지와 동일한 이름의 임의의 어노테이션을 만들어서 문서화되도록 하였습니다.
사용자 생성, 방 생성, 방 조회에 대한 문서도 작성해두었습니다.
<img width="1263" alt="image" src="https://github.com/user-attachments/assets/e561d83c-33f0-4dc2-8a3b-607dae761556" />

### 🛠️ 변경 사항
- [x] 스웨거 세팅
- [x] 구현된 컨트롤러 명세 추가
